### PR TITLE
Add __nonnull to hideDelay delay attribute

### DIFF
--- a/ios/ProgressHUD/HUDModule.m
+++ b/ios/ProgressHUD/HUDModule.m
@@ -72,7 +72,7 @@ RCT_EXPORT_METHOD(hide:(NSNumber* __nonnull)hudKey) {
     }
 }
 
-RCT_EXPORT_METHOD(hideDelay:(NSNumber* __nonnull)hudKey delay:(NSNumber *)ms) {
+RCT_EXPORT_METHOD(hideDelay:(NSNumber* __nonnull)hudKey delay:(NSNumber * __nonnull)ms) {
     HBDProgressHUD *hud = [self.huds objectForKey:hudKey];
     if (hud) {
         [self.huds removeObjectForKey:hudKey];


### PR DESCRIPTION
Otherwise react native raises error: "Argument 1 (NSNumber) of HUD.hideDelay has unspecified nullability but React requires that all NSNumber arguments are explicitly marked as `nonnull` to ensure compatibility with Android."